### PR TITLE
Added a double quote around object keys to sustain space in a key.

### DIFF
--- a/src/__test__/index.test.ts
+++ b/src/__test__/index.test.ts
@@ -16,7 +16,11 @@ describe("jexlExpressionStringFromAst", () => {
     ["foo .bar .baz", "foo.bar.baz"],
     ['foo["bar"].baz', null], // Stays as filter syntax
     ["foo  ? bar  : baz", "foo ? bar : baz"],
-    ["{ one: a.value, two: b.value }", "{ one: a.value, two: b.value }"], // Keys are not escaped. Keys in quotes give a Jexl syntax error
+    ["{ one: a.value, two: b.value }", '{ "one": a.value, "two": b.value }'],
+    [
+      '{ "one a": a.value, "two b": b.value }',
+      '{ "one a": a.value, "two b": b.value }',
+    ],
     ["! foo", "!foo"],
     ["foo.bar   ==   foo.baz", "foo.bar == foo.baz"],
     ['[true,"two",3]', '[true, "two", 3]'],

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,7 +106,7 @@ export function jexlExpressionStringFromAst(
       return `[${ast.value.map(recur).join(", ")}]`;
     case "ObjectLiteral":
       return `{ ${Object.entries(ast.value)
-        .map(([key, value]) => `${key}: ${recur(value)}`)
+        .map(([key, value]) => `"${key}": ${recur(value)}`)
         .join(", ")} }`;
     case "FilterExpression":
       return `${recur(ast.subject)}[${ast.relative ? "." : ""}${recur(


### PR DESCRIPTION
Changed `${key}: ${recur(value)} to "${key}": ${recur(value)}` , adding a double quote around object keys to sustain space in a key.

In current version it not possible to sustain objects like {"key with space": "A value"}